### PR TITLE
Add terminal GUI for Groq API testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Groq API Tester
+
+This repository contains a simple terminal user interface for interacting with the Groq API.
+
+## Requirements
+
+- Python 3.10+
+- A Groq API key available in the environment variable `GROQ_API_KEY`
+
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the GUI application with:
+
+```bash
+python groq_gui.py
+```
+
+Enter a prompt at the bottom of the interface and press **Enter**. The response from the Groq API will appear in the log window.

--- a/groq_gui.py
+++ b/groq_gui.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import asyncio
+from groq import Groq
+from textual.app import App, ComposeResult
+from textual.widgets import Header, Footer, Input, TextLog
+
+class GroqApp(App):
+    """Simple terminal UI for interacting with the Groq API."""
+
+    BINDINGS = [("ctrl+c", "quit", "Quit")]
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield TextLog(id="log", highlight=False)
+        yield Input(placeholder="Type your prompt and press Enter", id="prompt")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        self.client = Groq()
+        self.model = "llama3-groq-70b-8192-tool-use-preview"
+        self.query_one(Input).focus()
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:
+        prompt = event.value
+        event.input.value = ""
+        log = self.query_one(TextLog)
+        log.write(f"> {prompt}")
+        response = await self.call_groq(prompt)
+        log.write(response)
+        log.write("")
+
+    async def call_groq(self, prompt: str) -> str:
+        return await asyncio.to_thread(self._call_groq_sync, prompt)
+
+    def _call_groq_sync(self, prompt: str) -> str:
+        messages = [{"role": "user", "content": prompt}]
+        resp = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+        )
+        return resp.choices[0].message.content.strip()
+
+if __name__ == "__main__":
+    GroqApp().run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+groq
+textual
+


### PR DESCRIPTION
## Summary
- add Textual-based GUI to interact with the Groq API
- document requirements and usage
- list `groq` and `textual` dependencies

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*